### PR TITLE
Auto build Docker images on new releases

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 10 * * *"
+  
+name: auto build docker image
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      ret: ${{ steps.version-check-result.outputs.ret }}
+    steps:
+      - name: Compare Docker image version with v2fly release's
+        id: version-check-result
+        run: |
+          v2fly_release=$(curl -sSL --retry 5 https://api.github.com/repos/v2fly/v2ray-core/releases/latest | jq -r ".tag_name")
+          docker_tag=$(curl -sSL --retry 5 https://hub.docker.com/v2/repositories/v2fly/v2fly-core/tags | jq -r ".results[1].name")
+          ret=1
+          if [[ $v2fly_release != $docker_tag ]] && [[ $(printf '%s\n' $v2fly_release $docker_tag | sort -V | head -n1) == $docker_tag ]]; then ret=0; fi
+          echo "ret=$ret" >> $GITHUB_OUTPUT
+    
+  trigger-build:
+    needs: version-check
+    if: ${{ needs.version-check.outputs.ret == '0'}}
+    uses: ./.github/workflows/docker-push.yml
+    secrets: inherit

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -14,6 +14,7 @@ on:
       - "v2ray.sh"
       - "Dockerfile"
       - ".github/workflows/docker-push.yml"
+  workflow_call:
 
 name: docker push
 jobs:
@@ -38,7 +39,7 @@ jobs:
       - name: Get tag to build
         id: tag
         run: |
-          latest_tag=$(curl -sSL --retry 5 "https://api.github.com/repos/v2fly/v2ray-core/releases/latest" | jq .tag_name | awk -F '"' '{print $2}')
+          latest_tag=$(curl -sSL --retry 5 "https://api.github.com/repos/v2fly/v2ray-core/releases/latest" | jq -r ".tag_name")
           if [[ -z "${{ github.event.inputs.tag }}" ]]; then
             echo "Use the latest release tag of v2ray-core: ${latest_tag}"
             echo "tag=${latest_tag}" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://hub.docker.com/r/v2fly/v2fly-core
 ```bash
 docker run --rm v2fly/v2fly-core help
 
-docker run --name v2ray v2fly/v2fly-core $v2ray_args (help, eun etc...)
+docker run --name v2ray v2fly/v2fly-core $v2ray_args (help, run etc...)
 
 docker run -d --name v2ray -v /path/to/config.json:/etc/v2fly/config.json -p 10086:10086 v2fly/v2fly-core run -c /etc/v2fly/config.json 
 


### PR DESCRIPTION
As the title says.

Currently the build & push of docker images is manual, this would add a daily check and push newer docker image if there is a newer upstream release.