### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TAG
 COPY v2ray.sh "${WORKDIR}"/v2ray.sh
 
 RUN set -ex \
-    && apk add --no-cache ca-certificates \
+    && apk add --no-cache ca-certificates curl \
     && mkdir -p /etc/v2ray /usr/local/share/v2ray /var/log/v2ray \
     # forward request and error logs to docker log collector
     && ln -sf /dev/stdout /var/log/v2ray/access.log \


### PR DESCRIPTION
添加curl支持，在v2ray.sh 中，使用wget下载文件兼容性没有curl好，比如容器使用了 http_proxy 代理时，wget 就很容易会出现问题。